### PR TITLE
web: Update missing link and remove extra copywriting

### DIFF
--- a/src/pages/web.html
+++ b/src/pages/web.html
@@ -122,7 +122,7 @@ cta-line2: Oursky can help yours stand out.
                   </div>
                   <div data-aos="fade-up" data-aos-duration="800" data-aos-delay="550"
                      class="text-center medium-text-left">
-                     <h4>SEO and Web Performance Optimization</h4>
+                     <h4>SEO and Web Performance</h4>
                      <p>Search engine optimization (SEO) and web performance (the speed with which your content is
                         delivered to the user) are important for your project’s discoverability in search engines. We
                         help complete your SEO checklist and ensure that your web app is up to <a

--- a/src/pages/web.html
+++ b/src/pages/web.html
@@ -93,7 +93,8 @@ cta-line2: Oursky can help yours stand out.
                   <div data-aos="fade-up" data-aos-duration="800" data-aos-delay="450"
                      class="text-center medium-text-left">
                      <h4>User-Centered</h4>
-                     <p>Your users see and experience your app’s interface, not the codes. Our design philosophy uses an
+                     <p>Your users see and experience your app’s interface, not the codes. Our <a
+                           href="{{root}}design">design philosophy</a> uses an
                         iterative approach to translating your ideas into engaging user stories, flows, wireframes,
                         mockups, and prototypes.</p>
                   </div>


### PR DESCRIPTION
Skipped this one because the doc that the link is pointing to is not accessible. Adding it back as we've confirmed design philosophy is indeed the design page.

<img width="1054" alt="Screenshot 2020-08-26 at 5 05 37 PM" src="https://user-images.githubusercontent.com/18374475/91284351-5f7c3700-e7be-11ea-866d-7cf8fae2d04e.png">
