### PR TITLE
mobile-page: Update hyperlink colour in dark areas

### DIFF
--- a/src/assets/scss/_landing.scss
+++ b/src/assets/scss/_landing.scss
@@ -374,7 +374,7 @@
 			}
 
 			a {
-				color: #6c9ae8;
+				color: #ff9900;
 			}
 		}
 


### PR DESCRIPTION
The blue arrow is not a dynamic svg so we can't change the colour of it, added to #23 


<img width="801" alt="Screenshot 2020-08-27 at 11 09 16 AM" src="https://user-images.githubusercontent.com/18374475/91379712-e4665f80-e855-11ea-9532-a5da75d45e0d.png">


refs #74 