### PR TITLE
header: Remove software development from submenu

### DIFF
--- a/src/assets/scss/_header.scss
+++ b/src/assets/scss/_header.scss
@@ -90,7 +90,7 @@
 
 				}
 				li a {
-					font-size: 11px;
+					font-size: 13px;
 				}
 			}
 			&--about,
@@ -135,6 +135,7 @@
 					}
 					.service__proservice__name {
 						font-weight: 500;
+						font-size: 16px;
 					}
 				}
 			}

--- a/src/partials/header.html
+++ b/src/partials/header.html
@@ -58,9 +58,6 @@
 						</li>
 						<li><a href="{{root}}services">Services</a>
 							<ul class="header__dropmenu--services">
-								<li class="header__dropmenu__title"><a href="{{root}}services">Software Development
-										Services</a>
-								</li>
 								<li> <a href="{{root}}product-development">
 										<div class="service__proservice__item">
 											<div class="service__proservice__icon">


### PR DESCRIPTION
<img width="283" alt="Screenshot 2020-08-27 at 2 39 31 PM" src="https://user-images.githubusercontent.com/18374475/91400947-281b9200-e873-11ea-9ec2-b1759f522376.png">

refs #78 