### PR TITLE
mobile: hide menu if not visible

### DIFF
--- a/src/assets/scss/_header.scss
+++ b/src/assets/scss/_header.scss
@@ -378,7 +378,7 @@ header.black {
 
 .mobile__nav {
 	position: fixed;
-	
+	display: none;
 	left: 0;
 	width: 100%;
 	
@@ -420,6 +420,7 @@ header.black {
 	.service__proservice__item {
 		color: #fff;
 	}
+	display: block;
 }
 
 .mobile__nav__list {


### PR DESCRIPTION
The menu is blocking the footer that's why when you click on the email it will open the enquiry page instead.

refs #95 