### PR TITLE
Use landing button as triggering element for header fading

### DIFF
--- a/src/assets/js/app.js
+++ b/src/assets/js/app.js
@@ -20,9 +20,9 @@ $(document).foundation();
 var controller = new ScrollMagic.Controller({ globalSceneOptions: { duration: 0 } });
 
 // build scenes
-new ScrollMagic.Scene({ triggerElement: "#content" })
+new ScrollMagic.Scene({ triggerElement: "#landing__btn" })
   .setClassToggle(".header", "dark") // add class toggle
-  .offset(200)
+  .offset(150)
   .addTo(controller);
 
 /*$(function() {

--- a/src/pages/index.html
+++ b/src/pages/index.html
@@ -85,7 +85,7 @@ cta-line2: Oursky can help you create one.
           <div data-aos="fade-up" data-aos-once="false" data-aos-anchor-placement="center-bottom" data-aos-delay="80"
             data-aos-duration="900" data-aos-easing="ease-in-out">
 
-            <a class="landing__btn" href="{{root}}product-development">
+            <a id="landing__btn" class="landing__btn" href="{{root}}product-development">
 
               <h3 class="landing__btn__title">Learn More</h3>
               <p class="landing__btn__desc">How we digital transform business by design great digital products.


### PR DESCRIPTION

<img width="1199" alt="Screenshot 2020-08-31 at 4 21 48 PM" src="https://user-images.githubusercontent.com/18374475/91698947-1a814780-eba6-11ea-87e8-f9f213e89057.png">

<img width="325" alt="Screenshot 2020-08-31 at 4 20 48 PM" src="https://user-images.githubusercontent.com/18374475/91698888-01789680-eba6-11ea-9043-12ea7550d92e.png">

if it fades too early for desktop maybe we need to separate them into two settings.


refs #92 