### PR TITLE
Fix deployment extension

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -17,6 +17,7 @@ import autoprefixer from 'autoprefixer';
 import purgecss from 'gulp-purgecss';
 import uglify from 'gulp-uglify';
 import gulpIgnore from 'gulp-ignore';
+import rename from 'gulp-rename';
 
 // Load all Gulp plugins into one variable
 const $ = plugins();
@@ -64,6 +65,9 @@ function pages() {
       data: 'src/data/',
       helpers: 'src/helpers/'
     }))
+    .pipe($.if(PRODUCTION, rename({
+      extname: ""
+    })))
     .pipe(gulp.dest(PATHS.dist));
 }
 

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "foundation-sites": "^6.6.0",
     "gulp-ignore": "^3.0.0",
     "gulp-purgecss": "^2.3.0",
+    "gulp-rename": "^2.0.0",
     "gulp-uglify": "^3.0.2",
     "jquery": "^3.5.0",
     "motion-ui": "^2.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3837,6 +3837,11 @@ gulp-rename@^1.2.0:
   resolved "https://registry.yarnpkg.com/gulp-rename/-/gulp-rename-1.4.0.tgz#de1c718e7c4095ae861f7296ef4f3248648240bd"
   integrity sha512-swzbIGb/arEoFK89tPY58vg3Ok1bw+d35PfUNwWqdo7KM4jkmuGA78JiDNqR+JeZFaeeHnRg9N7aihX3YPmsyg==
 
+gulp-rename@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/gulp-rename/-/gulp-rename-2.0.0.tgz#9bbc3962b0c0f52fc67cd5eaff6c223ec5b9cf6c"
+  integrity sha512-97Vba4KBzbYmR5VBs9mWmK+HwIf5mj+/zioxfZhOKeXtx5ZjBk57KFlePf5nxq9QsTtFl0ejnHE3zTC9MHXqyQ==
+
 gulp-sass@^4.0.1:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/gulp-sass/-/gulp-sass-4.0.2.tgz#cfb1e3eff2bd9852431c7ce87f43880807d8d505"


### PR DESCRIPTION
s3 doesn't strip ".html" when serving the website so we would need to include the extension when access a webpage, eg `oursky.com/case-studies.html`, which is pretty ugly. As a workaround I've added another pipeline to remove the ".html" extension for all the pages when building for production.