### PR TITLE
Dismiss on window resize only if device is not large

### DIFF
--- a/src/assets/js/app.js
+++ b/src/assets/js/app.js
@@ -62,15 +62,14 @@ $('.header__mobilenav').click(function (e) {
   e.preventDefault();
 });
 
-$(document).ready(function (_) {
-  var width = $(window).width();
-  $(window).resize(function (e) {
-    if (width == $(window).width()) {
-      return;
-    }
-    $('.header__mobilenavbtn-x').removeClass("active");
-    $('.mobile__nav').removeClass("active");
-    $('.header').removeClass("black");
-    $('body').removeClass('noscroll');
-  });
+$(document).ready(function () {
+  // Threshold for a mobile nav menu to show is 64em according to zurb foundation
+  if (!window.matchMedia("(max-width: 64em)").matches) {
+    $(window).resize(function (e) {
+      $('.header__mobilenavbtn-x').removeClass("active");
+      $('.mobile__nav').removeClass("active");
+      $('.header').removeClass("black");
+      $('body').removeClass('noscroll');
+    });
+  }
 })


### PR DESCRIPTION
For some reason ipad fires a resize event when we switch app and occasionally does it when we close and reopen the browser app. 🙄  As a result we will only capture resize events from a desktop browser instead.

refs #139 